### PR TITLE
Ignore all other *.cl file type detection.

### DIFF
--- a/ftdetect/opencl.vim
+++ b/ftdetect/opencl.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile *.cl set filetype=opencl
+au! BufRead,BufNewFile *.cl set filetype=opencl


### PR DESCRIPTION
Hi @petRUShka,

Would you mind if I add this change to ignore all other *.cl file type detection?  Please let me if there is anything wrong.

> " Lisp (*.el = ELisp, *.cl = Common Lisp, *.jl = librep Lisp)
> if has("fname_case")
>   au BufNewFile,BufRead *.lsp,*.lisp,*.el,*.cl,*.jl,*.L,.emacs,.sawfishrc setf lisp
> else
>   au BufNewFile,BufRead *.lsp,*.lisp,*.el,*.cl,*.jl,.emacs,.sawfishrc setf lisp
> endif

It has such lines in the '/usr/share/vim/vim73/filetype.vim' on my Linux machine, which will match more patterns defined in the '/usr/share/vim/vim73/syntax/cl.vim'.  That is why I create this change to ignore that.

Thanks